### PR TITLE
buncha fixes and css line nums

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -28,7 +28,6 @@ module.exports.activate = context => {
         vscode.commands.executeCommand('editor.action.clipboardCopyAction');
         panel.postMessage({ type: 'update', ...getConfig() });
       };
-      update();
 
       const selectionHandler = vscode.window.onDidChangeTextEditorSelection(e => {
         if (!e.selections[0] || e.selections[0].isEmpty) return;

--- a/src/util.js
+++ b/src/util.js
@@ -1,22 +1,14 @@
 'use strict';
 
-const fs = require('fs');
-const { promisify } = require('util');
+const { readFile } = require('fs').promises;
 const path = require('path');
-
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
 
 const readHtml = async htmlPath => {
   const html = await readFile(htmlPath, 'utf-8');
-  return html.replace(/script src="([^"]*)"/g, (_, src) => {
-    const realSource = 'vscode-resource:' + path.resolve(htmlPath, '..', src);
-    return `script src="${realSource}"`;
-  });
+  return html.replace(
+    /script src="([^"]*)"/g,
+    (_, src) => `script src="vscode-resource:${path.resolve(htmlPath, '..', src)}"`
+  );
 };
 
-module.exports = {
-  readFile,
-  writeFile,
-  readHtml
-};
+module.exports = { readHtml };

--- a/webview/index.html
+++ b/webview/index.html
@@ -12,6 +12,7 @@
     <script src="./index.js" type="module" defer></script>
     <style>
       html {
+        --initial-line-number: 0;
         box-sizing: border-box;
         padding-top: 32px;
       }
@@ -24,10 +25,10 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        margin: auto;
         overflow: hidden;
-        resize: both;
         border-radius: 4px;
-        width: calc(100% - 4rem);
+        padding: 3em;
         background-color: #abb8c3;
       }
       #window {
@@ -36,8 +37,6 @@
         max-width: calc(100% - 128px);
         align-items: flex-start;
         flex-direction: column;
-        margin-top: 64px;
-        margin-bottom: 64px;
         min-width: 100px;
         max-width: 100%;
         border-radius: 5px;
@@ -52,27 +51,30 @@
         overflow: hidden;
       }
       #snippet {
-        display: flex;
         padding-top: 15px;
+        max-width: 100%;
+        white-space: pre-wrap;
+        word-break: break-all;
+        color: var(--vscode-editor-foreground);
+        background-color: var(--vscode-editor-background);
+        font-family: var(--vscode-editor-font-family);
+        font-size: calc(var(--vscode-editor-font-size) * 1px);
+        counter-reset: line-number var(--initial-line-number);
       }
       #snippet > div {
         display: flex;
-        flex-flow: column nowrap;
-        justify-content: center;
-        max-width: 100%;
-        white-space: pre-wrap !important;
-        word-break: break-all;
-        color: var(--vscode-editor-foreground);
-        background-color: var(--vscode-editor-background) !important;
-        font-family: var(--vscode-editor-font-family) !important;
       }
-      #snippet > div > div {
-        display: flex;
-        flex-wrap: wrap;
-      }
-      .line-number {
+      #snippet > div::before {
+        counter-increment: line-number;
+        content: counter(line-number);
         text-align: right;
         color: var(--vscode-editorLineNumber-foreground);
+        align-self: center;
+        padding-right: 18px;
+        width: calc(var(--vscode-editor-font-size) * var(--line-number-width) * 1px);
+      }
+      #snippet > div > div:last-child {
+        flex: 1;
       }
       #save-container {
         margin-top: 40px;

--- a/webview/index.js
+++ b/webview/index.js
@@ -1,33 +1,46 @@
-const snippetNode = document.getElementById('snippet');
+const $ = (q, c = document) => c.querySelector(q);
+const $$ = (q, c = document) => Array.from(c.querySelectorAll(q));
 
-const stripInitialIndent = node => {
-  const initialSpans = Array.from(node.querySelectorAll(':scope > div > span:first-child'));
-  if (initialSpans.some(span => !span.textContent.match(/^\s+/))) return;
-  const minIndent = Math.min(...initialSpans.map(span => span.textContent.match(/^\s+/)[0].length));
-  initialSpans.forEach(span => (span.textContent = span.textContent.slice(minIndent)));
-};
+const snippetNode = $('#snippet');
 
-const addLineNumbers = (node, startLine = 1) => {
-  Array.from(node.querySelectorAll(':scope > br')).forEach(
-    row => (row.outerHTML = '<div><span>&nbsp;</span></div>')
-  );
-  const rows = Array.from(node.querySelectorAll(':scope > div'));
-  rows.forEach((row, i) => {
-    const num = document.createElement('span');
-    num.classList.add('line-number');
-    row.prepend(num);
-    num.textContent = startLine + rows.length - 1;
-    num.style.width = num.clientWidth + 1 + 'px';
-    num.style.paddingRight = '20px';
-    num.textContent = startLine + i;
+const regIndent = /^\s+/;
+
+const addLineNumbers = node => {
+  $$(':scope > br', node).forEach(row => (row.outerHTML = '<div>&nbsp;</div>'));
+  const rows = $$(':scope > div', node);
+  node.style.setProperty('--line-number-width', rows.length.toString().length);
+  rows.forEach(row => {
+    const div = document.createElement('div');
+    row.replaceWith(div);
+    div.appendChild(row);
   });
 };
 
+const stripInitialIndent = node => {
+  const initialSpans = $$(':scope > div > span:first-child', node);
+  if (initialSpans.some(span => !regIndent.test(span.textContent))) return;
+  const minIndent = Math.min(
+    ...initialSpans.map(span => span.textContent.match(regIndent)[0].length)
+  );
+  initialSpans.forEach(span => (span.textContent = span.textContent.slice(minIndent)));
+};
+
+const getClipboardHtml = clip => {
+  const html = clip.getData('text/html');
+  if (html) return html;
+  const text = clip
+    .getData('text/plain')
+    .split('\n')
+    .map(line => `<div>${line}</div>`)
+    .join('');
+  return `<div>${text}</div>`;
+};
+
 document.addEventListener('paste', e => {
-  snippetNode.innerHTML = e.clipboardData.getData('text/html');
-  const div = snippetNode.querySelector('div');
-  stripInitialIndent(div);
-  addLineNumbers(div);
+  snippetNode.innerHTML = getClipboardHtml(e.clipboardData);
+  snippetNode.innerHTML = snippetNode.firstElementChild.innerHTML;
+  stripInitialIndent(snippetNode);
+  addLineNumbers(snippetNode);
 });
 
 window.addEventListener('message', e => {


### PR DESCRIPTION
- don't call update on init because old clipboard contents might get rendered
- simplified utils code
- don't allow resizing snippet-container
- dont use full width, just 3em
- render line numbers using css counters
- remove outer wrapper for pasted HTML and use editor vars to set base values
- fix handling for plain text documents