### PR TITLE
cleanup logic for reading conf

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -6,38 +6,35 @@ const { homedir } = require('os');
 const { readHtml, writeFile } = require('./util');
 const { copyImg } = require('./img-clipboard');
 
+const getSettings = (group, keys) => {
+  const settings = vscode.workspace.getConfiguration(group, null);
+  return keys.reduce((acc, k) => ((acc[k] = settings.get(k)), acc), {});
+};
+
 const getConfig = () => {
-  const editorSettings = vscode.workspace.getConfiguration('editor', null);
-  const extensionSettings = vscode.workspace.getConfiguration('codesnap', null);
-
-  const enableLigatures = editorSettings.get('fontLigatures', false);
+  const editorSettings = getSettings('editor', ['fontLigatures', 'tabSize']);
   const editor = vscode.window.activeTextEditor;
-  const tabSize = editor ? editor.options.tabSize : editorSettings.get('tabSize', 4);
+  if (editor) editorSettings.tabSize = editor.options.tabSize;
 
-  const backgroundColor = extensionSettings.get('backgroundColor', '#abb8c3');
-  const boxShadow = extensionSettings.get('boxShadow', 'rgba(0, 0, 0, 0.55) 0px 20px 68px');
-  const containerPadding = extensionSettings.get('containerPadding', '3em');
-  const roundedCorners = extensionSettings.get('roundedCorners', true);
-  const showWindowControls = extensionSettings.get('showWindowControls', true);
-  const showLineNumbers = extensionSettings.get('showLineNumbers', true);
-  const realLineNumbers = extensionSettings.get('realLineNumbers', false);
+  const extensionSettings = getSettings('codesnap', [
+    'backgroundColor',
+    'boxShadow',
+    'containerPadding',
+    'roundedCorners',
+    'showWindowControls',
+    'showLineNumbers',
+    'realLineNumbers',
+    'transparentBackground',
+    'target'
+  ]);
+
   const selection = editor && editor.selection;
-  const startLine = realLineNumbers ? (selection ? selection.start.line : 0) : 0;
-  const transparentBackground = extensionSettings.get('transparentBackground', false);
-  const target = extensionSettings.get('target', 'container');
+  const startLine = extensionSettings.realLineNumbers ? (selection ? selection.start.line : 0) : 0;
 
   return {
-    enableLigatures,
-    tabSize,
-    backgroundColor,
-    boxShadow,
-    containerPadding,
-    roundedCorners,
-    showWindowControls,
-    showLineNumbers,
-    startLine,
-    transparentBackground,
-    target
+    ...extensionSettings,
+    ...editorSettings,
+    startLine
   };
 };
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -3,13 +3,8 @@
 const vscode = require('vscode');
 const path = require('path');
 const { homedir } = require('os');
-const { readHtml, writeFile } = require('./util');
+const { readHtml, writeFile, getSettings } = require('./util');
 const { copyImg } = require('./img-clipboard');
-
-const getSettings = (group, keys) => {
-  const settings = vscode.workspace.getConfiguration(group, null);
-  return keys.reduce((acc, k) => ((acc[k] = settings.get(k)), acc), {});
-};
 
 const getConfig = () => {
   const editorSettings = getSettings('editor', ['fontLigatures', 'tabSize']);
@@ -32,8 +27,8 @@ const getConfig = () => {
   const startLine = extensionSettings.realLineNumbers ? (selection ? selection.start.line : 0) : 0;
 
   return {
-    ...extensionSettings,
     ...editorSettings,
+    ...extensionSettings,
     startLine
   };
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const vscode = require('vscode');
+
 const { readFile, writeFile } = require('fs').promises;
 const path = require('path');
 
@@ -11,4 +13,9 @@ const readHtml = async htmlPath => {
   );
 };
 
-module.exports = { readHtml, writeFile };
+const getSettings = (group, keys) => {
+  const settings = vscode.workspace.getConfiguration(group, null);
+  return keys.reduce((acc, k) => ((acc[k] = settings.get(k)), acc), {});
+};
+
+module.exports = { readHtml, writeFile, getSettings };


### PR DESCRIPTION
Defaults seem to work correctly from the `package.json` so repeating them again there seems counter productive to me. 

Unless you're aware of a scenario where it wouldn't work?

Otherwise a pretty standard refactor to remove repetitive calls to the vscode api and make it simpler to extend in future.