### PR TITLE
Allow using only a window title (no window controls)

### DIFF
--- a/webview/index.html
+++ b/webview/index.html
@@ -20,7 +20,7 @@
     <div id="snippet-container">
       <div id="window">
         <div id="navbar">
-          <div class="navbar-controls">
+          <div id="window-controls">
             <div class="red dot"></div>
             <div class="yellow dot"></div>
             <div class="green dot"></div>

--- a/webview/src/index.js
+++ b/webview/src/index.js
@@ -3,6 +3,7 @@ import { pasteCode } from './code.js';
 import { takeSnap, cameraFlashAnimation } from './snap.js';
 
 const navbarNode = $('#navbar');
+const windowControlsNode = $('#window-controls');
 const windowTitleNode = $('#window-title');
 const btnSave = $('#save');
 
@@ -26,6 +27,7 @@ window.addEventListener('message', ({ data: { type, ...cfg } }) => {
       containerPadding,
       roundedCorners,
       showWindowControls,
+      showWindowTitle,
       windowTitle
     } = config;
 
@@ -36,7 +38,12 @@ window.addEventListener('message', ({ data: { type, ...cfg } }) => {
     setVar('container-padding', containerPadding);
     setVar('window-border-radius', roundedCorners ? '4px' : 0);
 
-    navbarNode.hidden = !showWindowControls;
+
+    navbarNode.hidden = !showWindowControls && !showWindowTitle;
+    showWindowControls ? windowControlsNode.classList.remove('hidden') : windowControlsNode.classList.add('hidden');
+
+    windowTitleNode.hidden = !showWindowTitle;
+
     windowTitleNode.textContent = windowTitle;
 
     document.execCommand('paste');

--- a/webview/style.css
+++ b/webview/style.css
@@ -40,10 +40,13 @@ body {
   margin-bottom: 15px;
   text-align: center;
 }
-.navbar-controls {
+#window-controls {
   display: flex;
   float: left;
   margin-top: 2px;
+}
+#window-controls.hidden {
+  display: none;
 }
 #window-title {
   /* width of window controls (and a bit) so they don't overlap */


### PR DESCRIPTION
Currently the navbar is connector to the window controls, allowing three options:

1. no window controls no title (navbar hidden)
2. navbar with window controls, no title
3. navbar with window controls and title

This PR connects the navbar state to the window controls AND the title, meaning it adds fourth option (by disabling window controls but enabling title)

4. navbar with no window controls but with a title


![image](https://user-images.githubusercontent.com/734644/80965417-c7bf9b00-8e12-11ea-87db-d552859e4b2e.png)

`element.hidden = false` does not work for elements with children (the three dots) so I added a .hidden class for that element.

