### PR TITLE
feat: Add `shutterAction` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - You can also start CodeSnap by selecting code, right clicking, and clicking CodeSnap
 - If you'd like to bind CodeSnap to a hotkey, open up your keyboard shortcut settings and bind `codesnap.start` to a custom keybinding.
-- If you'd like to copy to clipboard instead of saving, click the image and press the copy keyboard shortcut (defaults are Ctrl+C on Windows and Linux, Cmd+C on OS X).
+- If you'd like to copy to clipboard instead of saving, click the image and press the copy keyboard shortcut (defaults are Ctrl+C on Windows and Linux, Cmd+C on OS X), or bind `codesnap.shutterAction` to `copy` in your settings
 - The extension will not function properly if `editor.copyWithSyntaxHighlighting` is set to false. Please ensure that it's set to true.
 
 ## Examples
@@ -60,6 +60,8 @@ CodeSnap is highly configurable. Here's a list of settings you can change to tun
 **`codesnap.transparentBackground`:** Boolean value to use a transparent background when taking the screenshot.
 
 **`codesnap.target`:** Either `container` to take the screenshot with the container, or `window` to only take the window.
+
+**`codesnap.shutterAction`:** Either `save` to save the screenshot into a file, or `copy` to copy the screenshot into the clipboard.
 
 ## Copy to Clipboard support in Linux
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
             "copy"
           ],
           "default": "save",
-          "description": "The behavior of the shutter action"
+          "description": "The behavior of the shutter button"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,16 @@
           ],
           "default": "container",
           "description": "Take the shot with or without the container"
+        },
+        "codesnap.shutterAction": {
+          "scope": "resource",
+          "type": "string",
+          "enum": [
+            "save",
+            "copy"
+          ],
+          "default": "save",
+          "description": "The behavior of the shutter action"
         }
       }
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -21,7 +21,8 @@ const getConfig = () => {
     'showLineNumbers',
     'realLineNumbers',
     'transparentBackground',
-    'target'
+    'target',
+    'shutterAction'
   ]);
 
   const selection = editor && editor.selection;
@@ -94,6 +95,8 @@ const runCommand = async (context) => {
     } else if (type === 'copy') {
       await copyImage(data);
       flash();
+    } else {
+      vscode.window.showErrorMessage(`CodeSnap 📸: Unknown shutterAction "${type}"`);
     }
   });
 

--- a/webview/src/index.js
+++ b/webview/src/index.js
@@ -11,7 +11,7 @@ let config;
 
 btnSave.addEventListener('click', () => takeSnap(config));
 
-document.addEventListener('copy', () => takeSnap(config, 'copy'));
+document.addEventListener('copy', () => takeSnap({ ...config, shutterAction: 'copy' }));
 
 document.addEventListener('paste', (e) => pasteCode(config, e.clipboardData));
 

--- a/webview/src/snap.js
+++ b/webview/src/snap.js
@@ -17,7 +17,7 @@ export const cameraFlashAnimation = async () => {
   flashFx.style.opacity = '1';
 };
 
-export const takeSnap = async (config, type = 'save') => {
+export const takeSnap = async (config) => {
   windowNode.style.resize = 'none';
   if (config.transparentBackground || config.target === 'window') {
     setVar('container-background-color', 'transparent');
@@ -36,7 +36,7 @@ export const takeSnap = async (config, type = 'save') => {
     }
   });
 
-  vscode.postMessage({ type, data: url.slice(url.indexOf(',') + 1) });
+  vscode.postMessage({ type: config.shutterAction, data: url.slice(url.indexOf(',') + 1) });
 
   windowNode.style.resize = 'horizontal';
   setVar('container-background-color', config.backgroundColor);


### PR DESCRIPTION
Addressing this issue https://github.com/kufii/CodeSnap/issues/18.

This won't change the current behavior. You still can save & copy like previously.
But you can tweek the shutter button action to either `save` (current bahavior) or `copy`

If there is any error in this configuration, I added an error message.
![image](https://user-images.githubusercontent.com/20936586/110371556-6decba80-804d-11eb-88e8-7f5ec5afed07.png)
