### PR TITLE
Removed workspace.name

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -31,7 +31,7 @@ const getConfig = () => {
   let windowTitle = '';
   if (editor && extensionSettings.showWindowTitle) {
     const activeFileName = editor.document.uri.path.split('/').pop();
-    windowTitle = `${vscode.workspace.name} - ${activeFileName}`;
+    windowTitle = `${activeFileName}`;
   }
 
   return {


### PR DESCRIPTION
I personally didn't like having the workspace name in the snap, you don't have to accept it however I would prefer if there was an option to remove it