### PR TITLE
Fix issue #66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -856,7 +856,8 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -917,14 +918,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "img-clipboard": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/img-clipboard/-/img-clipboard-1.1.0.tgz",
-      "integrity": "sha512-oPKwD+RVviDZ8IvYLDcs1aLodfYqSTPuXBgZUrXXYySeZb2UYVynj+Oh+b8YJvtkWXK6Ief5xu4+ri2BGI4ZsQ==",
-      "requires": {
-        "temp-write": "^4.0.0"
-      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -1014,11 +1007,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
-    },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -1131,14 +1119,6 @@
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
-      }
-    },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "requires": {
-        "semver": "^6.0.0"
       }
     },
     "minimatch": {
@@ -1455,11 +1435,6 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-    },
     "serialize-javascript": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -1622,23 +1597,6 @@
         }
       }
     },
-    "temp-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
-    },
-    "temp-write": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
-      "integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "is-stream": "^2.0.0",
-        "make-dir": "^3.0.0",
-        "temp-dir": "^1.0.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1713,11 +1671,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "vscode-test": "^1.5.2"
   },
   "dependencies": {
-    "dom-to-image-even-more": "^1.0.4",
-    "img-clipboard": "^1.1.0"
+    "dom-to-image-even-more": "^1.0.4"
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,7 +4,6 @@ const vscode = require('vscode');
 const path = require('path');
 const { homedir } = require('os');
 const { readHtml, writeFile, getSettings } = require('./util');
-const { copyImg, isWayland, ErrorCodes } = require('img-clipboard');
 
 const getConfig = () => {
   const editorSettings = getSettings('editor', ['fontLigatures', 'tabSize']);
@@ -70,16 +69,6 @@ const saveImage = async (data) => {
   uri && writeFile(uri.fsPath, Buffer.from(data, 'base64'));
 };
 
-const copyImage = async (data) => {
-  const [err, stdout, stderr] = await copyImg(Buffer.from(data, 'base64'));
-  if (!err) return;
-  if (err.code === ErrorCodes.COMMAND_NOT_FOUND && process.platform === 'linux')
-    vscode.window.showErrorMessage(
-      `CodeSnap: ${isWayland() ? 'wl-clipboard' : 'xclip'} is not installed`
-    );
-  else vscode.window.showErrorMessage('CodeSnap: ' + stdout + stderr);
-};
-
 const hasOneSelection = (selections) =>
   selections && selections.length === 1 && !selections[0].isEmpty;
 
@@ -97,9 +86,6 @@ const runCommand = async (context) => {
     if (type === 'save') {
       flash();
       await saveImage(data);
-    } else if (type === 'copy') {
-      await copyImage(data);
-      flash();
     } else {
       vscode.window.showErrorMessage(`CodeSnap 📸: Unknown shutterAction "${type}"`);
     }

--- a/webview/src/snap.js
+++ b/webview/src/snap.js
@@ -36,7 +36,17 @@ export const takeSnap = async (config) => {
     }
   });
 
-  vscode.postMessage({ type: config.shutterAction, data: url.slice(url.indexOf(',') + 1) });
+  const data = url.slice(url.indexOf(',') + 1);
+  if (config.shutterAction === 'copy') {
+    const binary = atob(data);
+    const array = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) array[i] = binary.charCodeAt(i);
+    const blob = new Blob([array], { type: 'image/png' });
+    navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+    cameraFlashAnimation();
+  } else {
+    vscode.postMessage({ type: config.shutterAction, data });
+  }
 
   windowNode.style.resize = 'horizontal';
   setVar('container-background-color', config.backgroundColor);


### PR DESCRIPTION
Upon inspecting the code, I realized that there's actually no need for the package `img-clipboard`, as the webview already have full access to the web APIs that is enough to achieve the image copying functionality. Inside snap.js, I convert the base64 data to a Blob object, and then just call `navigator.clipboard.write()` method to copy it. I hope this will be accepted as I really like this extension and I really want it to work.