### PR TITLE
use clipboardCopyWithSyntaxHighlightingAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 - You can also start CodeSnap by selecting code, right clicking, and clicking CodeSnap
 - If you'd like to bind CodeSnap to a hotkey, open up your keyboard shortcut settings and bind `codesnap.start` to a custom keybinding.
 - If you'd like to copy to clipboard instead of saving, click the image and press the copy keyboard shortcut (defaults are Ctrl+C on Windows and Linux, Cmd+C on OS X), or bind `codesnap.shutterAction` to `copy` in your settings
-- The extension will not function properly if `editor.copyWithSyntaxHighlighting` is set to false. Please ensure that it's set to true.
 
 ## Examples
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -87,7 +87,7 @@ const runCommand = async (context) => {
   const panel = await createPanel(context);
 
   const update = async () => {
-    await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
+    await vscode.commands.executeCommand('editor.action.clipboardCopyWithSyntaxHighlightingAction');
     panel.webview.postMessage({ type: 'update', ...getConfig() });
   };
 


### PR DESCRIPTION
There's an editor command called `editor.action.clipboardCopyWithSyntaxHighlightingAction` that allows you top copy the current selection to clipboard including syntax highlighting.
![image](https://user-images.githubusercontent.com/848652/124294648-ed832580-db25-11eb-9420-3a6dda13d6e5.png)

By using this command users can have the `editor.copyWithSyntaxHighlighting` setting set to whatever, and it won't interfere with CodeSnap
![image](https://user-images.githubusercontent.com/848652/124294760-0e4b7b00-db26-11eb-8bdd-a7c3d641efc5.png)

Related to https://github.com/kufii/CodeSnap/issues/24