### PR TITLE
Add "trim empty lines" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,12 @@
           ],
           "default": "save",
           "description": "The behavior of the shutter button"
+        },
+        "codesnap.trimEmptyLines": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Trim off empty lines at the beginning and at the end"
         }
       }
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -21,7 +21,8 @@ const getConfig = () => {
     'realLineNumbers',
     'transparentBackground',
     'target',
-    'shutterAction'
+    'shutterAction',
+    'trimEmptyLines'
   ]);
 
   const selection = editor && editor.selection;

--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -44,6 +44,16 @@ const stripInitialIndent = (node) => {
   initialSpans.forEach((span) => (span.textContent = span.textContent.slice(minIndent)));
 };
 
+const isEmptyLine = (node) => node.innerText.match(/^\s*$/);
+
+const trimEmptyLines = (node, config) => {
+  while(isEmptyLine(node.firstChild)) {
+    node.removeChild(node.firstChild);
+    if(config.realLineNumbers) config.startLine++;
+  }
+  while(isEmptyLine(node.lastChild)) node.removeChild(node.lastChild);
+}
+
 const getClipboardHtml = (clip) => {
   const html = clip.getData('text/html');
   if (html) return html;
@@ -62,5 +72,6 @@ export const pasteCode = (config, clipboard) => {
   snippetNode.style.lineHeight = code.style.lineHeight;
   snippetNode.innerHTML = code.innerHTML;
   stripInitialIndent(snippetNode);
+  if(config.trimEmptyLines) trimEmptyLines(snippetNode, config);
   setupLines(snippetNode, config);
 };


### PR DESCRIPTION
I think the suggestion is issue #70 is a great one, and indeed I also experienced the trouble caused by trailing empty lines, so I added this option (which, by the same logic, also trim off empty lines at the beginning as well). I had paid attention not to mess up the line numbers when `realLineNumbers` is enabled.

P.S. Sorry I forgot to modify README again, but I suppose you guys can help me fix that?